### PR TITLE
1번 API 카테고리 반환 타입 한글로 변경

### DIFF
--- a/src/main/java/sopt/seminar/sopt/common/config/WebConfig.java
+++ b/src/main/java/sopt/seminar/sopt/common/config/WebConfig.java
@@ -10,9 +10,8 @@ public class WebConfig implements WebMvcConfigurer {
   @Override
   public void addCorsMappings(CorsRegistry registry) {
     registry.addMapping("/api/**")
-        .allowedOrigins("http://localhost:5173")
+        .allowedOrigins("*")
         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-        .allowedHeaders("Authorization", "Content-Type", "memberId")
-        .allowCredentials(true);
+        .allowedHeaders("*");
   }
 }

--- a/src/main/java/sopt/seminar/sopt/reservation/entity/Category.java
+++ b/src/main/java/sopt/seminar/sopt/reservation/entity/Category.java
@@ -7,13 +7,14 @@ import lombok.Getter;
 @Getter
 public enum Category {
 
-  뷰티("beauty"),
-  생활_클래스("life_class"),
-  식당_카페("restaurant_cafe"),
-  숙박("accommodation"),
-  스포츠_레저("sports_leisure"),
-  공연_전시("performance_exhibition"),
-  병의원("hospital"),
+  beauty("뷰티","beauty"),
+  life_class("생활/클래스","life_class"),
+  restaurant_cafe("식당/카페","restaurant_cafe"),
+  accommodation("숙박","accommodation"),
+  sports_leisure("스포츠/레저","sports_leisure"),
+  performance_exhibition("공연/전시","performance_exhibition"),
+  hospital("병의원","hospital"),
   ;
-  private final String category;
+  private final String korean;
+  private final String english;
 }

--- a/src/main/java/sopt/seminar/sopt/reservation/entity/Reservation.java
+++ b/src/main/java/sopt/seminar/sopt/reservation/entity/Reservation.java
@@ -4,6 +4,8 @@ import static jakarta.persistence.GenerationType.*;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -43,7 +45,9 @@ public class Reservation extends BaseEntity {
 
   private Integer price;
 
-  private String category;
+  @Column(name = "category")
+  @Enumerated(EnumType.STRING)
+  private Category category;
 
   @Column(name = "review_status")
   private boolean reviewStatus;
@@ -52,7 +56,7 @@ public class Reservation extends BaseEntity {
   private boolean starStatus;
 
   public Reservation(Member member, Store store, String content, String mainDescription,
-      String subDescription, Integer price, String category) {
+      String subDescription, Integer price, Category category) {
     this.member = member;
     this.store = store;
     this.content = content;

--- a/src/main/java/sopt/seminar/sopt/reservation/service/ReservationQueryService.java
+++ b/src/main/java/sopt/seminar/sopt/reservation/service/ReservationQueryService.java
@@ -27,7 +27,7 @@ public class ReservationQueryService {
 
     Member member = memberQueryService.findById(memberId);
     return findAllReservationByMember(member).stream().map(reservation ->
-        ReservationCategorizedResponse.of(reservation.getId(), reservation.getCategory(), member.getName(),
+        ReservationCategorizedResponse.of(reservation.getId(), reservation.getCategory().getKorean(), member.getName(),
             reservation.getStore().getStoreName(), reservation.getCreatedAt(),
             reservation.getMainDescription(), reservation.getSubDescription(),
             reservation.getPrice(),


### PR DESCRIPTION
## What is this PR? 📄

- Explanation : 1번 API 카테고리 반환 타입 한글로 변경합니다. 
- Github Issue Number: # 
- 기타 관련 문서 :

## Changes 📝

(e.g. 내역 상세 화면에서 금액 입력 및 Validate 로직을 수정합니다.)

- restaurant_cafe -> 레스토랑/카페 (예시) 


## Screenshot 📷



## Test Checklist ✅

- [ ] 금액 999,999,999,999원을 초과하지 않는지 확인
- [ ] 계산서 금액과 999,999,999,999원을 초과하지 않는지 확인
- [ ] 불필요한 코드, 컨벤션 일치 확인

## Notation

